### PR TITLE
ci: Add Tests for PHP > 8.1, drop support for composer v1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,14 @@ jobs:
                     - '7.4'
                     - '8.0'
                     - '8.1'
+                    - '8.2'
+                    - '8.3'
+                    - '8.4'
+                    - '8.5'
                 tools: [ "composer:v1", "composer:v2" ]
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v6
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -36,7 +40,7 @@ jobs:
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             -   name: Cache composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: ${{ steps.composercache.outputs.dir }}
                     key: composer-${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('composer.*') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
                     - '8.3'
                     - '8.4'
                     - '8.5'
-                tools: [ "composer:v1", "composer:v2" ]
+                tools: [ "composer:v2" ]
 
         steps:
             -   uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
 
             -   name: Get composer cache directory
                 id: composercache
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             -   name: Cache composer dependencies
                 uses: actions/cache@v4

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "class": "Fidry\\Composer\\InheritancePlugin\\InheritancePlugin"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "wikimedia/composer-merge-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.0 || ^2.0"
+        "composer/composer": "^2.0"
     },
     "conflict": {
         "composer/composer": ">=2.0,<2.0.13"


### PR DESCRIPTION
bump github action versions

migrate cache path
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.com/shivammathur/setup-php?tab=readme-ov-file#cache-composer-dependencies

Is support for composer v1 still needed?
Runs fail, that is why i removed it.